### PR TITLE
do not hardcode bash path

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 aclocal -I m4
 # Use the glibtoolize command in OSX
 case "$OSTYPE" in


### PR DESCRIPTION
Some systems put `bash` outside of `/usr/bin` prefix (for example, as `/usr/local/bin/bash`), that's why the recommended way to call `bash` in a script is to call it via `/usr/bin/env`.