### PR TITLE
do not look for pybind11 while using --disable-python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,8 @@ then
         AC_SUBST([PYBIND11_CPPFLAGS])
         AC_SUBST([SYSTEM_HAS_PYBIND11]) # Used by Makefile.am in plugins/script/
     fi
+else
+    AM_CONDITIONAL([SYSTEM_HAS_PYBIND11], [false])
 fi
 
 # dynamic link library


### PR DESCRIPTION
I noticed that `configure` aborts because of `SYSTEM_HAS_PYBIND11` not being set even when `--disable-python` is used.

I don't understand very much how autotools work so the fix proposed is pure cargo cult programming. There is probably a proper way to do it, if so, help is welcome. :wink: 