### PR TITLE
Clean up removed plugin Makefiles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -348,9 +348,7 @@ AC_CONFIG_FILES([install/darkradiant.desktop install/i18n//Makefile.in
                  plugins/archivezip/Makefile
                  plugins/commandsystem/Makefile
                  plugins/eclassmgr/Makefile
-                 plugins/eclasstree/Makefile
                  plugins/entity/Makefile
-                 plugins/entitylist/Makefile
                  plugins/eventmanager/Makefile
                  plugins/filetypes/Makefile
                  plugins/filters/Makefile
@@ -366,7 +364,6 @@ AC_CONFIG_FILES([install/darkradiant.desktop install/i18n//Makefile.in
                  plugins/skins/Makefile
                  plugins/sound/Makefile
                  plugins/uimanager/Makefile
-                 plugins/undo/Makefile
                  plugins/vfspk3/Makefile
                  plugins/xmlregistry/Makefile
                  plugins/dm.stimresponse/Makefile


### PR DESCRIPTION
Ref this bug: http://bugs.thedarkmod.com/view.php?id=4742

And this forum post: http://forums.thedarkmod.com/topic/19312-configure-fails-with-cannot-find-input-file-makefilein/


`autogen.sh` fails:

```
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:24: installing './compile'
configure.ac:2: installing './missing'
configure.ac:336: error: required file 'plugins/eclasstree/Makefile.in' not found
configure.ac:336: error: required file 'plugins/entitylist/Makefile.in' not found
configure.ac:336: error: required file 'plugins/undo/Makefile.in' not found
libs/ddslib/Makefile.am: installing './depcomp'
```

The rest of the output in the bug report/forum post is from `configure`, since the user runs it even if `autogen.sh` has already exited non-zero. The directories `plugins/{eclasstree,entitylist,undo}` don't exist anymore, and without references to the makefiles in `configure.ac`, it configures and builds just fine.

Tangentially, I have a [Gentoo ebuild](https://github.com/varingst/varingst-overlay/tree/master/dev-games/darkradiant) for DR if you'd like one.
