### PR TITLE
Add `monster_player_clip_wood` to list of filtered clip textures

### DIFF
--- a/install/games/darkmod.game
+++ b/install/games/darkmod.game
@@ -86,6 +86,7 @@
 				action="hide" />
 			<filterCriterion type="texture" match="textures/common/clip(_plusmovables)*$" action="hide" />
 			<filterCriterion type="texture" match="textures/common/moveableclipmodel" action="hide" />
+			<filterCriterion type="texture" match="textures/common/monster_player_clip_wood" action="hide" />
 		</filter>
 		<filter name="Trigger Textures">
 			<filterCriterion


### PR DESCRIPTION
**Problem description:** 
`textures/common/monster_player_clip_wood` is not being filtered out by the Filter > Clip Textures menu option in Dark Radiant, because there is no filter criterion entry that matches this name. (I'm not even sure how often this texture is used, but it is a valid clip texture afaik)

**Possible solution**
Add a matching filter to `install/games/darkmod.game`. Instead of adding a new filter, we could also try to make the existing filters more general so that it will match this texture as well.