### PR TITLE
Avoid out-of-bound access on corner cases / when readlink fails.

### DIFF
--- a/libs/module/ApplicationContextBase.cpp
+++ b/libs/module/ApplicationContextBase.cpp
@@ -187,7 +187,7 @@ const char* LINK_NAME =
 /// brief Returns the filename of the executable belonging to the current process, or 0 if not found.
 std::string getExecutablePath(char* argv[])
 {
-    char buf[PATH_MAX];
+    char buf[PATH_MAX+1];
 
     // Now read the symbolic link
     int ret = readlink(LINK_NAME, buf, PATH_MAX);
@@ -203,6 +203,7 @@ std::string getExecutablePath(char* argv[])
             // In case of an error, leave the handling up to the caller
             return std::string();
         }
+        ret = strlen(path);
     }
 
     /* Ensure proper NUL termination */


### PR DESCRIPTION
When looking if I could enable Hurd support (Hurd does not have PATH_MAX), I spotted these two out-of-bound bugs in getExecutablePath()

1) if readlink fails, (returns -1), but the fallback worked, ret will still be -1, so the code will "Nul-Terminate" at buf[-1] (

2) readlink might return PATH_MAX. In this case, the nul termination will write buf[PATH_MAX], one byte beyond the array.
 For this, it is easiest to just allocate 1 byte more for the array.
