### PR TITLE
Add missing image dimension reads to Quake 3 legacy brush parser

### DIFF
--- a/radiantcore/map/format/primitiveparsers/BrushDef.h
+++ b/radiantcore/map/format/primitiveparsers/BrushDef.h
@@ -27,7 +27,7 @@ public:
     scene::INodePtr parse(parser::DefTokeniser& tok) const;
 
 private:
-    static Matrix4 getTexDef(float shiftS, float shiftT, float rotation, float scaleS, float scaleT);
+    static Matrix4 getTexDef(std::string shader, float shiftS, float shiftT, float rotation, float scaleS, float scaleT);
 };
 typedef std::shared_ptr<LegacyBrushDefParser> LegacyBrushDefParserPtr;
 


### PR DESCRIPTION
I believe there is no exporter for that brush format so that would mean the
Q3 legacy brushes would be converted to Q3 non-legacy brushes on write,
if there is no bug on the writing part. That other brush format is compatible
with NetRadiant and the q3map2 map compiler so that would not be a big issue.

See that thread for work-in-progress status with the Q3-map based Unvanquished game:

- https://forums.unvanquished.net/viewtopic.php?f=9&t=2121

[![Unvanquished chasm map in DarkRadiant, with Q3 legacy brush support](https://dl.illwieckz.net/b/darkradiant/shots/unvanquished/20210303-053527-000.darkradiant-q3legacybrush-unvanquished-chasm-map.png)](https://dl.illwieckz.net/b/darkradiant/shots/unvanquished/20210303-053527-000.darkradiant-q3legacybrush-unvanquished-chasm-map.png)