### PR TITLE
PatchDefExporter: do not write trailing white space after shader name

### DIFF
--- a/radiantcore/map/format/primitivewriters/PatchDefExporter.h
+++ b/radiantcore/map/format/primitivewriters/PatchDefExporter.h
@@ -159,11 +159,11 @@ private:
 			if (string::starts_with(shaderName, GlobalTexturePrefix_get()))
 			{
 				// Q3-style patchDef2 doesn't write the "textures/" prefix to the map, cut it off
-				stream << "" << shader_get_textureName(shaderName.c_str()) << " ";
+				stream << shader_get_textureName(shaderName.c_str());
 			}
 			else
 			{
-				stream << "" << shaderName << " ";
+				stream << shaderName;
 			}
 		}
 		stream << "\n";


### PR DESCRIPTION
Do not write trailing white space after shader name when writing Q3 PatchDef format.

Otherwise it writes something like this (white space “ ” replaced by “⎵” character to make it obvious):

```
patchDef2
{
shared_vega/panel07⎵
( 3 3 0 0 0 )
(
…
```

Instead of:

```
patchDef2
{
shared_vega/panel07
( 3 3 0 0 0 )
(
…
```

This would also add a lot of diff noise when one contributor uses DarkRadiant and another contributor uses another Radiant, those lines would be entirely rewritten on saving to add or remove the trailing white space given one editor or another is used.