### PR TITLE
Fix building when precompiled headers are turned off.

### DIFF
--- a/include/itexturetoolmodel.h
+++ b/include/itexturetoolmodel.h
@@ -5,6 +5,7 @@
 #include "Bounded.h"
 #include "iselection.h"
 #include "iselectiontest.h"
+#include "iselectable.h"
 #include "imanipulator.h"
 #include "editable.h"
 #include <sigc++/signal.h>

--- a/radiant/eventmanager/ModifierHintPopup.h
+++ b/radiant/eventmanager/ModifierHintPopup.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <wx/popupwin.h>
+#include <wx/window.h>
+#include <wx/stattext.h>
+#include <wx/sizer.h>
 #include "MouseToolManager.h"
 
 namespace ui

--- a/radiant/eventmanager/MouseToolManager.cpp
+++ b/radiant/eventmanager/MouseToolManager.cpp
@@ -12,6 +12,8 @@
 #include "module/StaticModule.h"
 #include "ModifierHintPopup.h"
 
+#include <wx/frame.h>
+
 namespace ui
 {
 

--- a/radiant/map/AutoSaveTimer.cpp
+++ b/radiant/map/AutoSaveTimer.cpp
@@ -1,7 +1,9 @@
 #include "AutoSaveTimer.h"
 
+#include "ipreferencesystem.h"
 #include "iautosaver.h"
 #include "registry/registry.h"
+#include "i18n.h"
 
 namespace map
 {

--- a/radiant/textool/TexTool.cpp
+++ b/radiant/textool/TexTool.cpp
@@ -27,7 +27,9 @@
 #include "textool/tools/TextureToolMouseEvent.h"
 
 #include <wx/sizer.h>
+#include <wx/button.h>
 #include <wx/toolbar.h>
+
 
 namespace ui
 {

--- a/radiant/ui/common/SoundChooser.cpp
+++ b/radiant/ui/common/SoundChooser.cpp
@@ -4,6 +4,7 @@
 #include "isound.h"
 #include "ui/imainframe.h"
 #include "ifavourites.h"
+#include "registry/registry.h"
 
 #include "wxutil/dataview/ThreadedResourceTreePopulator.h"
 #include "wxutil/dataview/VFSTreePopulator.h"
@@ -16,8 +17,10 @@
 #include "ui/UserInterfaceModule.h"
 
 #include <wx/sizer.h>
-#include "wxutil/Bitmap.h"
 #include <wx/button.h>
+#include <wx/stattext.h>
+
+#include "wxutil/Bitmap.h"
 #include <sigc++/functors/mem_fun.h>
 
 #include <functional>

--- a/radiant/ui/layers/LayerControlDialog.cpp
+++ b/radiant/ui/layers/LayerControlDialog.cpp
@@ -21,6 +21,8 @@
 
 #include "scene/LayerUsageBreakdown.h"
 
+#include <map>
+
 namespace ui
 {
 

--- a/radiant/ui/lightinspector/LightInspector.cpp
+++ b/radiant/ui/lightinspector/LightInspector.cpp
@@ -1,6 +1,7 @@
 #include "LightInspector.h"
 
 #include "i18n.h"
+#include "icameraview.h"
 #include "ientity.h"
 #include "ieclass.h"
 #include "igame.h"
@@ -15,7 +16,9 @@
 #include <wx/checkbox.h>
 #include <wx/artprov.h>
 #include <wx/stattext.h>
+#include <wx/slider.h>
 #include <wx/radiobut.h>
+
 
 #include "ui/common/ShaderChooser.h" // for static displayLightInfo() function
 #include "util/ScopedBoolLock.h"

--- a/radiant/ui/lightinspector/LightInspector.h
+++ b/radiant/ui/lightinspector/LightInspector.h
@@ -15,6 +15,8 @@
 class Entity;
 class wxColourPickerEvent;
 
+class wxSlider;
+
 namespace ui
 {
 

--- a/radiant/ui/statusbar/CommandStatus.cpp
+++ b/radiant/ui/statusbar/CommandStatus.cpp
@@ -1,5 +1,6 @@
 #include "CommandStatus.h"
 
+#include "i18n.h"
 #include "ui/istatusbarmanager.h"
 #include "iradiant.h"
 

--- a/radiantcore/entity/doom3group/Doom3GroupNode.h
+++ b/radiantcore/entity/doom3group/Doom3GroupNode.h
@@ -3,6 +3,7 @@
 #include "igroupnode.h"
 #include "icurve.h"
 #include "irenderable.h"
+#include "editable.h"
 #include "../OriginKey.h"
 #include "../RotationKey.h"
 #include "../NameKey.h"

--- a/radiantcore/map/algorithm/Models.h
+++ b/radiantcore/map/algorithm/Models.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace map
 {
 

--- a/radiantcore/map/format/Quake3Utils.h
+++ b/radiantcore/map/format/Quake3Utils.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "math/Plane3.h"
 #include "math/Vector3.h"
 #include "math/Matrix4.h"
 #include "texturelib.h"
+#include "ibrush.h"
 
 namespace map
 {

--- a/radiantcore/map/format/primitiveparsers/BrushDef.h
+++ b/radiantcore/map/format/primitiveparsers/BrushDef.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ibrush.h"
 #include "imapformat.h"
 #include "math/Matrix3.h"
 

--- a/radiantcore/model/import/openfbx/ofbx.cpp
+++ b/radiantcore/model/import/openfbx/ofbx.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <cstring>
 
 
 namespace ofbx

--- a/radiantcore/scenegraph/SceneGraph.h
+++ b/radiantcore/scenegraph/SceneGraph.h
@@ -9,6 +9,7 @@
 #include "imodule.h"
 #include "ispacepartition.h"
 #include "imap.h"
+#include "iundo.h"
 
 namespace scene
 {

--- a/radiantcore/selection/algorithm/Texturing.cpp
+++ b/radiantcore/selection/algorithm/Texturing.cpp
@@ -4,6 +4,9 @@
 #include "selection/textool/PatchNode.h"
 #include "messages/TextureChanged.h"
 
+#include "ipatch.h"
+#include "ibrush.h"
+
 namespace selection
 {
 

--- a/radiantcore/selection/textool/FaceNode.cpp
+++ b/radiantcore/selection/textool/FaceNode.cpp
@@ -4,6 +4,8 @@
 #include "itexturetoolcolours.h"
 #include "math/Matrix3.h"
 
+#include <GL/glew.h>
+
 namespace textool
 {
 

--- a/radiantcore/selection/textool/Node.cpp
+++ b/radiantcore/selection/textool/Node.cpp
@@ -1,7 +1,10 @@
 #include "Node.h"
 
+#include "math/Vector2.h"
+#include "math/Matrix4.h"
 #include "itexturetoolcolours.h"
 #include <sigc++/functors/mem_fun.h>
+#include <GL/glew.h>
 
 namespace textool
 {

--- a/radiantcore/selection/textool/Node.h
+++ b/radiantcore/selection/textool/Node.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include "render/Colour4.h"
 #include "math/AABB.h"
 #include "itexturetoolmodel.h"
 #include "ObservedSelectable.h"

--- a/radiantcore/selection/textool/PatchNode.cpp
+++ b/radiantcore/selection/textool/PatchNode.cpp
@@ -2,6 +2,8 @@
 
 #include "ipatch.h"
 #include "math/Matrix3.h"
+#include "math/Matrix4.h"
+#include <GL/glew.h>
 
 namespace textool
 {

--- a/radiantcore/selection/textool/PatchNode.h
+++ b/radiantcore/selection/textool/PatchNode.h
@@ -5,6 +5,7 @@
 #include "Node.h"
 
 class IPatch;
+struct PatchControl;
 
 namespace textool
 {

--- a/radiantcore/selection/textool/TextureToolDragManipulator.cpp
+++ b/radiantcore/selection/textool/TextureToolDragManipulator.cpp
@@ -3,6 +3,7 @@
 #include "itexturetoolmodel.h"
 #include "math/Matrix3.h"
 #include "pivot.h"
+#include "igrid.h"
 #include "selection/SelectionPool.h"
 
 namespace textool

--- a/radiantcore/selection/textool/TextureToolManipulationPivot.cpp
+++ b/radiantcore/selection/textool/TextureToolManipulationPivot.cpp
@@ -1,5 +1,6 @@
 #include "TextureToolManipulationPivot.h"
 
+#include "math/AABB.h"
 #include "itexturetoolmodel.h"
 
 namespace textool

--- a/radiantcore/selection/textool/TextureToolRotateManipulator.cpp
+++ b/radiantcore/selection/textool/TextureToolRotateManipulator.cpp
@@ -3,10 +3,12 @@
 #include "iselectiontest.h"
 #include "itexturetoolmodel.h"
 #include "itexturetoolcolours.h"
+#include "ishaders.h"
 #include "selection/BestPoint.h"
 #include "selection/SelectionPool.h"
 #include "pivot.h"
 #include "math/Matrix3.h"
+#include "registry/registry.h"
 
 namespace textool
 {

--- a/radiantcore/selection/textool/TextureToolSelectionSystem.cpp
+++ b/radiantcore/selection/textool/TextureToolSelectionSystem.cpp
@@ -1,5 +1,8 @@
 #include "TextureToolSelectionSystem.h"
 
+#include "igrid.h"
+#include "ishaders.h"
+#include "iundo.h"
 #include "itextstream.h"
 #include "iradiant.h"
 #include "module/StaticModule.h"

--- a/radiantcore/selection/textool/TextureToolSelectionSystem.h
+++ b/radiantcore/selection/textool/TextureToolSelectionSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include "itexturetoolmodel.h"
 #include "icommandsystem.h"
 #include "TextureToolManipulationPivot.h"


### PR DESCRIPTION
When building with "cmake -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On",
the build breaks due to several missing includes. This PR fixes that.

(my selfish rationale: precompiled headers seems to break my ccache setup,
and the packaging work for Debian usually includes a tons of rebuilds, so not
be able to use ccache slows me down significantly)