### PR TITLE
Fix build error on 32 bit archs.

### DIFF
--- a/radiantcore/model/import/openfbx/ofbx.h
+++ b/radiantcore/model/import/openfbx/ofbx.h
@@ -1,26 +1,21 @@
 #pragma once
 
+#include <cstdint>
 
 namespace ofbx
 {
 
 
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-#ifdef _WIN32
-	typedef long long i64;
-	typedef unsigned long long u64;
-#else
-	typedef long i64;
-	typedef unsigned long u64;
-#endif
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef int64_t i64;
+typedef uint64_t u64;
 
 static_assert(sizeof(u8) == 1, "u8 is not 1 byte");
 static_assert(sizeof(u32) == 4, "u32 is not 4 bytes");
 static_assert(sizeof(u64) == 8, "u64 is not 8 bytes");
 static_assert(sizeof(i64) == 8, "i64 is not 8 bytes");
-
 
 using JobFunction = void (*)(void*);
 using JobProcessor = void (*)(JobFunction, void*, void*, u32, u32);


### PR DESCRIPTION
OpenFBX does not typedef types correctly, leading to triggering the
static_asserts on 32-bit architectures.

This commit changes the typedefs to use C++11 uintXX_t types instead.

Edit: Build error caused by this: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001110
