### PR TITLE
Fix snapcraft.yaml file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: darkradiant
-version: '2.5.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: '2.14.0' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Level editing tool for The Dark Mod and Doom 3
 description: |
   DarkRadiant is a level editing tool for the open source stealth game The Dark
@@ -7,23 +7,112 @@ description: |
   possible to edit levels for Doom 3 and possibly other games using a similar
   engine, such as Quake 4, although these are not officially supported.
 
-grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
-
+base: core20
+grade: stable
+confinement: strict
+#confinement: devmode
 apps:
   darkradiant:
-    command: desktop-launch $SNAP/bin/darkradiant
+    command: usr/local/bin/darkradiant
+    desktop: usr/local/share/applications/darkradiant.desktop
     plugs: [desktop, gsettings, home, opengl, pulseaudio, x11]
-
 parts:
   darkradiant:
-    after: [desktop-gtk2]
-    plugin: autotools
-    configflags:
-      - --enable-debug
-      - --enable-darkmod-plugins
-      - --enable-relocation
-      - --disable-rpath
-      - --disable-python
-    install-via: prefix
+    plugin: cmake
     source: .
+    source-type: local
+    #make-parameters: ["FLAVOR=gtk2"]
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr/local
+    #   - --enable-debug
+    #   - -ENABLE_DM_PLUGINS
+    #   - -ENABLE_RELOCATION
+    build-packages:
+      - build-essential
+      - libgtk2.0-dev
+      - pkg-config
+      - zlib1g-dev
+      - libjpeg-dev
+      - libwxgtk3.0-gtk3-dev
+      - libxml2-dev
+      - libsigc++-2.0-dev
+      - libpng-dev
+      - libftgl-dev
+      - libglew-dev
+      - libalut-dev
+      - libvorbis-dev
+      - python3-dev
+      - libgtest-dev
+      - libeigen3-dev
+      - libgit2-dev
+    stage-packages:
+      - libasound2
+      - libatk-bridge2.0-0
+      - libatk1.0-0
+      - libatspi2.0-0
+      - libcairo-gobject2
+      - libcairo2
+      - libdatrie1
+      - libepoxy0
+      - libfontconfig1
+      - libfreetype6
+      - libfribidi0
+      - libftgl2
+      - libgdk-pixbuf2.0-0
+      - libgit2-28
+      - libgl1
+      - libglew2.1
+      - libglu1-mesa
+      - libglvnd0
+      - libglx0
+      - libgraphite2-3
+      - libgtk-3-0
+      - libharfbuzz0b
+      - libhttp-parser2.9
+      - libice6
+      - libicu66
+      - libjbig0
+      - libjpeg-turbo8
+      - libmbedcrypto3
+      - libmbedtls12
+      - libmbedx509-0
+      - libnotify4
+      - libogg0
+      - libopenal1
+      - libpango-1.0-0
+      - libpangocairo-1.0-0
+      - libpangoft2-1.0-0
+      - libpixman-1-0
+      - libpng16-16
+      - libpython3.8
+      - libsigc++-2.0-0v5
+      - libsm6
+      - libsndio7.0
+      - libssh2-1
+      - libthai0
+      - libtiff5
+      - libvorbis0a
+      - libvorbisfile3
+      - libwayland-client0
+      - libwayland-cursor0
+      - libwayland-egl1
+      - libwebp6
+      - libwxbase3.0-0v5
+      - libwxgtk3.0-gtk3-0v5
+      - libx11-6
+      - libxau6
+      - libxcb-render0
+      - libxcb-shm0
+      - libxcb1
+      - libxcomposite1
+      - libxcursor1
+      - libxdamage1
+      - libxdmcp6
+      - libxext6
+      - libxfixes3
+      - libxi6
+      - libxinerama1
+      - libxkbcommon0
+      - libxml2
+      - libxrandr2
+      - libxrender1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,9 +13,10 @@ confinement: strict
 #confinement: devmode
 apps:
   darkradiant:
+    extensions: [gnome-3-38]
     command: usr/local/bin/darkradiant
     desktop: usr/local/share/applications/darkradiant.desktop
-    plugs: [desktop, gsettings, home, opengl, pulseaudio, x11]
+    plugs: [desktop, gsettings, home, removable-media, opengl, pulseaudio, x11]
 parts:
   darkradiant:
     plugin: cmake


### PR DESCRIPTION
I've been working on making the snapcraft.yaml file in the git repository to work (again?) I've got the program compiling and running, but it's throwing some weird errors when you try and open the file browser I'm still trying to understand, but it's definitely a start as before It wasn't compiling at all.

the crash if anyone's curious:
```
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/i
mage-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Bail out! Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x1
6/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
zsh: abort (core dumped)  darkradiant
```