### PR TITLE
Fix Hurd build (ish)

### DIFF
--- a/plugins/dm.gameconnection/clsocket/StatTimer.h
+++ b/plugins/dm.gameconnection/clsocket/StatTimer.h
@@ -51,7 +51,7 @@
   #include <time.h>
 #endif
 
-#ifdef __linux__
+#ifdef __linux__ || __GNU__
   #include <stdio.h>
   #include <sys/time.h>
 #endif


### PR DESCRIPTION
When the clsocket code was copied over, the `#ifdef` was changed from `_LINUX`, which is defined [here](https://github.com/DFHack/clsocket/blob/master/CMakeLists.txt#L34) as any non-apple platform that CMake counts as unix, to a specific `__linux__` check.

Thus, platforms that are unix-like and have `stdio.h` and `sys/time.h` but do not define `__linux__`, such as Hurd, break the build because they have no way of including them and thus finding `gettimeofday`.