### PR TITLE
Fix broken install instructions for icons and metadata.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,14 +171,14 @@ install(DIRECTORY install/ui DESTINATION ${PKGDATADIR}
         FILES_MATCHING PATTERN "*.ttf" PATTERN "*.xrc")
 install(DIRECTORY install/resources DESTINATION ${PKGDATADIR})
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/bitmaps/darkradiant_icon_64x64.png
-	    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/64x64/apps
-		RENAME net.darkradiant.DarkRadiant.png)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/bitmaps/darkradiant_icon_128x128.png
-	    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps
-		RENAME net.darkradiant.DarkRadiant.png)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/install/net.darkradiant.DarkRadiant.metainfo.xml
-	    DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+install(FILES ${PROJECT_SOURCE_DIR}/install/bitmaps/darkradiant_icon_64x64.png
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/64x64/apps
+        RENAME net.darkradiant.DarkRadiant.png)
+install(FILES ${PROJECT_SOURCE_DIR}/install/bitmaps/darkradiant_icon_128x128.png
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps
+        RENAME net.darkradiant.DarkRadiant.png)
+install(FILES ${PROJECT_SOURCE_DIR}/install/net.darkradiant.DarkRadiant.metainfo.xml
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 
 # Install locale data
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14")


### PR DESCRIPTION
Fixes at make install time:
```
CMake Error at cmake_install.cmake:554 (file):
  file INSTALL cannot find
  "/build/darkradiant-3.4.0/obj-x86_64-linux-gnu/install/bitmaps/darkradiant_icon_64x64.png":
  No such file or directory.

```