### PR TITLE
Include utility in EntityClass.cpp

### DIFF
--- a/radiantcore/eclass/EntityClass.cpp
+++ b/radiantcore/eclass/EntityClass.cpp
@@ -8,6 +8,7 @@
 #include "string/predicate.h"
 #include <fmt/format.h>
 #include <functional>
+#include <utility>
 
 namespace eclass
 {


### PR DESCRIPTION
It fixes this build error on my end:

```
radiantcore/eclass/EntityClass.cpp: In member function ‘virtual EntityClassAttribute& eclass::EntityClass::getAttribute(const std::string&, bool)’:
radiantcore/eclass/EntityClass.cpp:321:14: error: ‘as_const’ is not a member of ‘std’; did you mean ‘is_const’?
  321 |         std::as_const(*this).getAttribute(name, includeInherited)
      |              ^~~~~~~~
      |              is_const
```