### PR TITLE
Improve mouse cursor hiding consistency when the pointer is captured.

### DIFF
--- a/libs/wxutil/FreezePointer.cpp
+++ b/libs/wxutil/FreezePointer.cpp
@@ -28,7 +28,7 @@ void FreezePointer::startCapture(wxWindow* window,
 
     if (_hidePointer)
     {
-        topLevel->SetCursor(wxCursor(wxCURSOR_BLANK));
+        window->SetCursor(wxCursor(wxCURSOR_BLANK));
     }
 
     // We capture the mouse on the toplevel app, coordinates
@@ -92,7 +92,7 @@ void FreezePointer::endCapture()
 
     if (_hidePointer)
     {
-        topLevel->SetCursor(wxCursor(wxCURSOR_DEFAULT));
+        window->SetCursor(wxCursor(wxCURSOR_DEFAULT));
     }
 
     if (topLevel->HasCapture())

--- a/radiant/RadiantApp.cpp
+++ b/radiant/RadiantApp.cpp
@@ -89,7 +89,15 @@ public:
 };
 
 RadiantApp::RadiantApp()
-{}
+{
+#if defined(__linux__)
+    // The native Wayland backend for GTK does not implement the mouse pointer
+    // warping functions used in the FreezePointer class.  Forcing the backend
+    // to X11 will let us run using XWayland which does provide emulation of
+    // this functionality.
+    setenv("GDK_BACKEND", "x11", 0);
+#endif
+}
 
 RadiantApp::~RadiantApp()
 {}

--- a/radiant/xyview/OrthoView.cpp
+++ b/radiant/xyview/OrthoView.cpp
@@ -423,6 +423,9 @@ bool OrthoView::checkChaseMouse(unsigned int state)
 
 void OrthoView::setCursorType(CursorType type)
 {
+    if (_freezePointer.isCapturing(_wxGLWidget))
+        return;
+
     switch (type)
 	{
     case CursorType::Pointer:


### PR DESCRIPTION
This fixes issues under Wayland when dragging the 2D and 3D views.

This should probably be tested on Windows and pure X11 (rather than XWayland) to make sure it doesn't cause any problems.