### PR TITLE
Fix segfaults in skin editor

### DIFF
--- a/libs/wxutil/dataview/ThreadedResourceTreePopulator.cpp
+++ b/libs/wxutil/dataview/ThreadedResourceTreePopulator.cpp
@@ -30,6 +30,9 @@ ThreadedResourceTreePopulator::~ThreadedResourceTreePopulator()
 
 void ThreadedResourceTreePopulator::ThrowIfCancellationRequested()
 {
+    if (This() != this)
+        return;
+
     if (TestDestroy())
     {
         throw ThreadAbortedException();

--- a/radiant/ui/skin/SkinEditor.cpp
+++ b/radiant/ui/skin/SkinEditor.cpp
@@ -709,13 +709,14 @@ void SkinEditor::onSkinNameChanged(wxCommandEvent& ev)
 
     // Rename the active skin decl
     auto nameEntry = static_cast<wxTextCtrl*>(ev.GetEventObject());
-
-    GlobalModelSkinCache().renameSkin(_skin->getDeclName(), nameEntry->GetValue().ToStdString());
-    auto item = _skinTreeView->GetTreeModel()->FindString(_skin->getDeclName(), _columns.declName);
+    auto newSkin = nameEntry->GetValue().ToStdString();
+    GlobalModelSkinCache().renameSkin(_skin->getDeclName(), newSkin);
+    auto item = _skinTreeView->GetTreeModel()->FindString(newSkin, _columns.declName);
 
     // Make sure the item is selected again, it will be de-selected by the rename operation
     _skinTreeView->Select(item);
     _skinTreeView->EnsureVisible(item);
+    _skin = getSelectedSkin();
     handleSkinSelectionChanged(); // also updates all controls
 
     nameEntry->SetFocus();


### PR DESCRIPTION
This fixes two crashes I observed in the skin editor:

1. The ThreadedDeclarationTreePopulator  has public functions used by SkinEditorTreeView that eventually call ThrowIfCancellationRequested(), which is only valid to do  when called by the worker thread.  I added a check that simply returns from that function when it's not called on the worker thread.

2. GlobalModelSkinCache().renameSkin() appears to have a side effect that clears out the _skin member variable.  This variable was referenced afterwards causing a crash.  I reworked that code to cache the name and restore the _skin member afterwards.

This fixes the crashes, but it's just the tip of the iceberg when it comes to the usability of the skin editor (at least on Linux).  