### PR TITLE
Use packaged version of pugixml, if it is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,14 @@ pkg_check_modules(ZLIB zlib REQUIRED)
 pkg_check_modules(GLIB glib-2.0 REQUIRED)
 pkg_check_modules(EIGEN eigen3 REQUIRED)
 
+# Locate a packaged pugixml, if installed if not, fall back to embedded code copy.
+find_package(pugixml QUIET)
+if (TARGET pugixml::pugixml)
+    message(NOTICE "Distribution pugixml found and used.")
+else()
+    include_directories(libs/pugixml)
+endif()
+
 # Locate wxWidgets
 find_package(wxWidgets REQUIRED
              COMPONENTS base core stc adv gl xrc aui)

--- a/libs/xmlutil/CMakeLists.txt
+++ b/libs/xmlutil/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(xmlutil Document.cpp Node.cpp)
+
+# link with system puixml if we have it.
+if (TARGET pugixml::pugixml)
+  target_link_libraries(xmlutil PUBLIC pugixml::pugixml)
+endif()

--- a/libs/xmlutil/Document.h
+++ b/libs/xmlutil/Document.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "Node.h"
-#include "pugixml/pugixml.hpp"
 
+#include <pugixml.hpp>
 #include <mutex>
 #include <string>
 #include <optional>

--- a/libs/xmlutil/Node.h
+++ b/libs/xmlutil/Node.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "pugixml/pugixml.hpp"
-
+#include <pugixml.hpp>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This avoids an embedded code copy for for pugixml, as required by Debian (and other distributions) policies

The patch will look for an installed (system) pugixml, and if it finds it it will use this one instead of the one ln libs/pugixml

