### PR TITLE
User scripts

### DIFF
--- a/include/ui/ieventmanager.h
+++ b/include/ui/ieventmanager.h
@@ -202,6 +202,8 @@ public:
 	/* greebo: Retrieves the string representation of the given event
 	 */
 	virtual std::string getEventStr(wxKeyEvent& ev) = 0;
+
+	virtual void connectDeferredAccelerators() = 0;
 };
 
 // Global accessor for the event manager

--- a/plugins/script/PythonModule.cpp
+++ b/plugins/script/PythonModule.cpp
@@ -309,7 +309,7 @@ ScriptCommand::Ptr PythonModule::createScriptCommand(const std::string& scriptBa
             }
 
             // Successfully retrieved the command
-            return std::make_shared<ScriptCommand>(cmdName, cmdDisplayName, relativeScriptPath);
+            return std::make_shared<ScriptCommand>(cmdName, cmdDisplayName, relativeScriptPath, scriptBasePath);
         }
 
         rError() << "Script file " << relativeScriptPath << " does not export a __commandName__ value" << std::endl;

--- a/plugins/script/ScriptCommand.cpp
+++ b/plugins/script/ScriptCommand.cpp
@@ -7,10 +7,12 @@ namespace script
 
 ScriptCommand::ScriptCommand(const std::string& name,
 							 const std::string& displayName,
-							 const std::string& scriptFilename) :
+							 const std::string& scriptFilename,
+							 const std::string& basePath) :
 	_name(name),
 	_displayName(displayName),
-	_scriptFilename(scriptFilename)
+	_scriptFilename(scriptFilename),
+	_basePath(basePath)
 {
 	// Register this with the command system
 	GlobalCommandSystem().addStatement(_name, "RunScriptCommand '" + _name + "'", false);

--- a/plugins/script/ScriptCommand.h
+++ b/plugins/script/ScriptCommand.h
@@ -23,12 +23,15 @@ private:
 	// The script file name to execute (relative to scripts/ folder)
 	std::string _scriptFilename;
 
+	std::string _basePath;
+
 public:
     using Ptr = std::shared_ptr<ScriptCommand>;
 
 	ScriptCommand(const std::string& name,
 				  const std::string& displayName,
-				  const std::string& scriptFilename);
+				  const std::string& scriptFilename,
+				  const std::string& basePath);
 
 	~ScriptCommand() override;
 
@@ -45,6 +48,11 @@ public:
 	const std::string& getDisplayName() const override
     {
 		return _displayName;
+	}
+
+	const std::string& getBasePath() const
+    {
+		return _basePath;
 	}
 };
 

--- a/plugins/script/ScriptingSystem.cpp
+++ b/plugins/script/ScriptingSystem.cpp
@@ -31,10 +31,12 @@
 
 #include "PythonModule.h"
 #include "SceneNodeBuffer.h"
+#include "ui/ieventmanager.h"
 
 #include "os/path.h"
 #include <functional>
 #include "string/case_conv.h"
+#include "settings/SettingsManager.h"
 
 namespace script
 {
@@ -95,6 +97,8 @@ void ScriptingSystem::initialise()
 
     // Search script folder for commands
     reloadScripts();
+
+    GlobalEventManager().connectDeferredAccelerators();
 }
 
 void ScriptingSystem::runScriptFile(const cmd::ArgumentList& args)
@@ -138,12 +142,12 @@ void ScriptingSystem::executeCommand(const std::string& name)
     UndoableCommand cmd("runScriptCommand " + name);
 
     // Execute the script file behind this command
-    executeScriptFile(found->second->getFilename(), true);
+    _pythonModule->executeScriptFile(found->second->getBasePath(), found->second->getFilename(), true);
 }
 
-void ScriptingSystem::loadCommandScript(const std::string& scriptFilename)
+void ScriptingSystem::loadCommandScript(const std::string& basePath, const std::string& scriptFilename)
 {
-    auto command = _pythonModule->createScriptCommand(_scriptPath, scriptFilename);
+    auto command = _pythonModule->createScriptCommand(basePath, scriptFilename);
 
     if (!command)
     {
@@ -173,29 +177,37 @@ void ScriptingSystem::reloadScripts()
     _commands.clear();
 
     // Initialise the search's starting point
-    fs::path start = fs::path(_scriptPath) / COMMAND_PATH;
-
-    if (!fs::exists(start))
+    auto scanDirectory = [&](const std::string& basePath)
     {
-        rWarning() << "Couldn't find scripts folder: " << start.string() << std::endl;
-        return;
-    }
+        fs::path start = fs::path(basePath) / COMMAND_PATH;
 
-    for (fs::recursive_directory_iterator it(start);
-         it != fs::recursive_directory_iterator(); ++it)
+        if (!fs::exists(start))
+        {
+            return;
+        }
+
+        for (fs::recursive_directory_iterator it(start);
+             it != fs::recursive_directory_iterator(); ++it)
+        {
+            const fs::path& candidate = *it;
+
+            if (fs::is_directory(candidate)) continue;
+
+            std::string extension = os::getExtension(candidate.string());
+            string::to_lower(extension);
+
+            if (extension != PYTHON_FILE_EXTENSION) continue;
+
+            // Script file found, construct a new command
+            loadCommandScript(basePath, os::getRelativePath(candidate.generic_string(), basePath));
+        }
+    };
+
+    scanDirectory(_scriptPath);
+
+    if (!_userScriptPath.empty())
     {
-        // Get the candidate
-        const fs::path& candidate = *it;
-
-        if (fs::is_directory(candidate)) continue;
-
-        std::string extension = os::getExtension(candidate.string());
-        string::to_lower(extension);
-
-        if (extension != PYTHON_FILE_EXTENSION) continue;
-
-        // Script file found, construct a new command
-        loadCommandScript(os::getRelativePath(candidate.generic_string(), _scriptPath));
+        scanDirectory(_userScriptPath);
     }
 
     rMessage() << "ScriptModule: Found " << _commands.size() << " commands." << std::endl;
@@ -207,6 +219,9 @@ void ScriptingSystem::initialiseModule(const IApplicationContext& ctx)
 {
     // Construct the script path
     _scriptPath = ctx.getRuntimeDataPath() + SCRIPT_PATH;
+
+    settings::SettingsManager manager(ctx);
+    _userScriptPath = manager.getCurrentVersionSettingsFolder() + SCRIPT_PATH;
 
     // Set up the python interpreter
     _pythonModule.reset(new PythonModule);
@@ -274,6 +289,7 @@ void ScriptingSystem::shutdownModule()
 
     _commands.clear();
     _scriptPath.clear();
+    _userScriptPath.clear();
     _pythonModule.reset();
 }
 

--- a/plugins/script/ScriptingSystem.h
+++ b/plugins/script/ScriptingSystem.h
@@ -22,6 +22,7 @@ class ScriptingSystem: public IScriptingSystem
 
     // The path where the script files are hosted
     std::string _scriptPath;
+    std::string _userScriptPath;
 
     // All named script commands (pointing to .py files)
     std::map<std::string, ScriptCommand::Ptr> _commands;
@@ -74,7 +75,7 @@ public:
 private:
     void executeScriptFile(const std::string& filename, bool setExecuteCommandAttr);
     void reloadScripts();
-    void loadCommandScript(const std::string& scriptFilename);
+    void loadCommandScript(const std::string& basePath, const std::string& scriptFilename);
 };
 typedef std::shared_ptr<ScriptingSystem> ScriptingSystemPtr;
 

--- a/radiant/eventmanager/EventManager.cpp
+++ b/radiant/eventmanager/EventManager.cpp
@@ -83,6 +83,7 @@ void EventManager::shutdownModule()
 	saveEventListToRegistry();
 
 	_accelerators.clear();
+	_deferredAccelerators.clear();
 	_events.clear();
 }
 
@@ -107,6 +108,7 @@ void EventManager::resetAcceleratorBindings()
 	}
 
 	_accelerators.clear();
+	_deferredAccelerators.clear();
 
 	for (const auto& pair : _menuItems)
 	{
@@ -406,7 +408,9 @@ Accelerator& EventManager::connectAccelerator(int keyCode, unsigned int modifier
 	}
 	else
 	{
-		return _emptyAccelerator;
+		rMessage() << "EventManager: Deferring shortcut for not-yet-registered command: " << command << std::endl;
+		_deferredAccelerators.emplace(command, accelerator);
+		return *accelerator;
 	}
 
 	auto result = _accelerators.emplace(command, accelerator);
@@ -634,6 +638,50 @@ void EventManager::saveEventListToRegistry()
 		if (pair.second->isEmpty()) continue;
 
 		shortcutSaver.visit(pair.first, *pair.second);
+	}
+
+	for (const auto& pair : _deferredAccelerators)
+	{
+		if (pair.second->isEmpty()) continue;
+
+		shortcutSaver.visit(pair.first, *pair.second);
+	}
+}
+
+void EventManager::connectDeferredAccelerators()
+{
+	auto it = _deferredAccelerators.begin();
+
+	while (it != _deferredAccelerators.end())
+	{
+		const auto& command = it->first;
+		auto& accelerator = it->second;
+
+		auto event = findEvent(command);
+
+		if (!event->empty())
+		{
+			accelerator->setEvent(event);
+		}
+		else if (GlobalCommandSystem().commandExists(command))
+		{
+			accelerator->setStatement(command);
+		}
+		else
+		{
+			++it;
+			continue;
+		}
+
+		rMessage() << "EventManager: Resolved deferred shortcut for " << command << std::endl;
+
+		_accelerators.emplace(command, accelerator);
+
+		std::string acceleratorStr = accelerator->getString(true);
+		setMenuItemAccelerator(command, acceleratorStr);
+		setToolItemAccelerator(command, acceleratorStr);
+
+		it = _deferredAccelerators.erase(it);
 	}
 }
 

--- a/radiant/eventmanager/EventManager.h
+++ b/radiant/eventmanager/EventManager.h
@@ -32,6 +32,7 @@ private:
 	// The command-to-accelerator map containing all registered shortcuts
 	typedef std::map<std::string, Accelerator::Ptr> AcceleratorMap;
 	AcceleratorMap _accelerators;
+	AcceleratorMap _deferredAccelerators;
 
 	// The map of all registered events
 	EventMap _events;
@@ -91,6 +92,8 @@ public:
 	void loadAccelerators() override;
 
 	void foreachEvent(IEventVisitor& eventVisitor) override;
+
+	void connectDeferredAccelerators() override;
 
 	// Tries to locate an accelerator, that is connected to the given command
 	Accelerator& findAccelerator(wxKeyEvent& ev);


### PR DESCRIPTION
This allows scripts to be loaded from a users home directory. For example: if a user added a script to `~/.config/darkradiant/3.9/scripts/commands/example.py`, that command would not be picked up. 

Additionally, there was a bug that if a script was attached to a hotkey, it would get wiped. Reported here: https://forums.thedarkmod.com/index.php?/topic/3499-wishlist-for-darkradiant/page/38/#findComment-507582