### PR TITLE
Added missing light to MD5 viewer scene graph

### DIFF
--- a/radiant/ui/animationpreview/AnimationPreview.cpp
+++ b/radiant/ui/animationpreview/AnimationPreview.cpp
@@ -178,6 +178,15 @@ void AnimationPreview::setupSceneGraph()
 
 	// This entity is acting as our root node in the scene
 	getScene()->setRoot(_root);
+
+	auto lightClass = GlobalEntityClassManager().findClass("light");
+	if (lightClass)
+	{
+		_light = GlobalEntityModule().createEntity(lightClass);
+		_light->tryGetEntity()->setKeyValue("light_radius", "750 750 750");
+		_light->tryGetEntity()->setKeyValue("origin", "150 150 150");
+		_root->addChildNode(_light);
+	}
 }
 
 void AnimationPreview::onModelRotationChanged()

--- a/radiant/ui/animationpreview/AnimationPreview.h
+++ b/radiant/ui/animationpreview/AnimationPreview.h
@@ -25,6 +25,9 @@ private:
 	// Each model node needs a parent entity to be properly renderable
 	EntityNodePtr _entity;
 
+	// Light to illuminate the model in lighting mode
+	scene::INodePtr _light;
+
 	// The animation to play on this model
 	md5::IMD5AnimPtr _anim;
 


### PR DESCRIPTION
This caused the "Lighting" mode of the MD5 preview to be completely dark.